### PR TITLE
Add custom parser kwargs handling and fix inconsistency between file/log monitoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -253,3 +253,6 @@ $RECYCLE.BIN/
 .vscode
 *.key
 *.plaintext
+
+# neovim
+.null-ls*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: '^tests'
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-toml
       - id: check-yaml
@@ -16,7 +16,7 @@ repos:
       - id: check-added-large-files
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.11.1
     hooks:
       - id: mypy
         args: ["--ignore-missing-imports"]
@@ -36,18 +36,18 @@ repos:
       - id: check_pdb_hook
         pass_filenames: false
   - repo: https://github.com/econchick/interrogate
-    rev: 1.5.0
+    rev: 1.7.0
     hooks:
       - id: interrogate
         args: [--verbose]
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.7
+    rev: 1.7.9
     hooks:
     -   id: bandit
         args: [-lll, --recursive, clumper]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.3
+    rev: v0.6.1
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix]

--- a/docs/custom_parsers.md
+++ b/docs/custom_parsers.md
@@ -72,3 +72,31 @@ with multiparser.FileMonitor(timeout=10) as monitor:
 
 In the case where you would like your parser function to accept additional keyword arguments you can add these
 to the definition and pass them to tracking using the `parser_kwargs` argument.
+
+## Class methods as parsers
+
+When custom parsers are decorated any positional and keyword arguments are propagated through, i.e.:
+
+```python
+@log_parser
+def my_parser(a_position_arg, file_content, a_keyword_argument):
+  ...
+```
+
+will be called as:
+
+```python
+my_parser(*args, file_content=file_content, **kwargs)
+```
+
+This allows class methods to also work as custom parsers because `self` is handled correctly:
+
+```python
+class MyClass:
+  def __init__(self):
+    ...
+
+  @log_parser
+  def my_parser(self, file_content):
+    ...
+```

--- a/docs/custom_parsers.md
+++ b/docs/custom_parsers.md
@@ -4,7 +4,7 @@ In the situation where the output files from a process are not processable by an
 
 ## File Parsers
 
-File parsers are used for tracking, they take the path of an identified candidate as an argument, parse the data from that file and return a key-value mapping of the data of interest. To create a custom parser you will need to use the `multiparser.parsing.file.file_parser` decorator. The function should take an argument `file_path` which is the file path, and allow an arbitrary number of additional arguments (`**_`) to be compatible with the decorator. It should return either:
+File parsers are used for tracking, they take the path of an identified candidate as an argument, parse the data from that file and return a key-value mapping of the data of interest. To create a custom parser you will need to use the `multiparser.parsing.file.file_parser` decorator. The function should take an argument `input_file` which is the file path, and allow an arbitrary number of additional arguments (`**_`) to be compatible with the decorator. It should return either:
 
     - Two dictionaries containing relevant metadata (usually left blank), and the parsed information: `{...}, {...}`.
     - A single dictionary representing the metadata, and a list of dictionaries (for cases where multiple lines are read in a single parse and these should be kept separate): `{...}, [{...}, ...]`
@@ -14,7 +14,7 @@ from typing import Any
 import multiparser.parsing.file as mp_file_parse
 
 @mp_file_parse.file_parser
-def parse_user_file_type(file_path: str, **_) -> tuple[dict[str, Any], dict[str, Any]]:
+def parse_user_file_type(input_file: str, **_) -> tuple[dict[str, Any], dict[str, Any]]:
     with open(file_path) as in_f:
         file_lines = in_f.readlines()
 

--- a/docs/tracking_and_tailing.md
+++ b/docs/tracking_and_tailing.md
@@ -3,6 +3,7 @@
 In Multiparser there are two main ways in which changes to a file can be monitored, **tracking** which focuses on revisions of a file and **tailing** which looks at incremental additions.
 
 ## Tracking
+
 When a file is _tracked_ it is read in its entirety each time a change is dedicated. For example in the case of JSON and TOML files the data are held as key-value pairs which may be modified during the execution of a process.
 
 ```python
@@ -12,13 +13,23 @@ monitor.track(
 )
 ```
 
-
 ## Tailing
+
 When a file is _tailed_ only the most recent additions to the file are read, for example in the case of log files we are only interested in the most recent lines written to the file and can ignore those already parsed previously. This is particularly important when reading large outputs where logs can be kilobytes or even megabytes in size.
 
 ```python
 monitor.tail(
     path_glob_exprs="*.log",
     tracked_values=[r"(\w+)=([\d\.]+)]
+)
+```
+
+## Excluding files
+
+Files can be excluded from monitoring using the `exclude` method of `FileMonitor` with either a list or string:
+
+```python
+monitor.exclude(
+  ["test*.log"]
 )
 ```

--- a/multiparser/monitor.py
+++ b/multiparser/monitor.py
@@ -24,7 +24,6 @@ import multiprocessing
 import re
 import string
 import sys
-import tempfile
 import threading
 import inspect
 import time
@@ -272,7 +271,7 @@ class FileMonitor:
         _func_signature = inspect.signature(parser)
         _parameters = list(_func_signature.parameters.values())
 
-        if not "file_content" in (p.name for p in _parameters):
+        if "file_content" not in (p.name for p in _parameters):
             raise AssertionError(
                 f"Expected keyword argument 'file_content' in definition of parser function '{parser.__name__}'"
             )
@@ -380,7 +379,7 @@ class FileMonitor:
 
         if parser_func:
             _parameters = list(inspect.signature(parser_func).parameters.values())
-            if not "input_file" in (p.name for p in _parameters):
+            if "input_file" not in (p.name for p in _parameters):
                 raise AssertionError(
                     f"Expected keyword argument 'input_file' in definition of parser function '{parser_func.__name__}'"
                 )

--- a/multiparser/monitor.py
+++ b/multiparser/monitor.py
@@ -277,6 +277,14 @@ class FileMonitor:
                 f"Expected keyword argument 'file_content' in definition of parser function '{parser.__name__}'"
             )
 
+        # The function must have **_ or **kwargs in the definition, this allows passing of internal
+        # parameters prefixed with '__'
+        if not any(p.kind == inspect.Parameter.VAR_KEYWORD for p in _parameters):
+            raise AssertionError(
+                f"Function '{parser.__name__}' must allow arbitrary number of keyword arguments, "
+                "i.e. use '**_'"
+            )
+
         _test_str = string.ascii_lowercase
         _test_str += string.ascii_uppercase
         _test_str += string.ascii_letters
@@ -378,10 +386,19 @@ class FileMonitor:
                 )
             # Either the parser itself is decorated, or a function it calls to create the parsed data
             # is decorated, either should add timestamp information
-            if not parser_func.__name__.endswith("__mp_parser") and "timestamp" not in _out[0]:
+            if not parser_func.__name__.endswith("__mp_parser"):
                 raise AssertionError(
                     f"Parser function '{parser_func.__name__}' must be decorated using the "
                     "multiparser.file_parser decorator"
+                )
+
+            # The function must have **_ or **kwargs in the definition, this allows passing of internal
+            # parameters prefixed with '__'
+            print([p.kind for p in _parameters])
+            if not any(p.kind == inspect.Parameter.VAR_KEYWORD for p in _parameters):
+                raise AssertionError(
+                    f"Function '{parser_func.__name__}' must allow arbitrary number of keyword arguments, "
+                    "i.e. use '**_'"
                 )
 
         if isinstance(path_glob_exprs, str):

--- a/multiparser/parsing/file.py
+++ b/multiparser/parsing/file.py
@@ -56,6 +56,9 @@ def file_parser(parser: typing.Callable) -> typing.Callable:
     on which file is being passed as well as the last modified time
     for that file.
 
+    This decorator has been designed to work with both functions and
+    class methods.
+
     Parameters
     ----------
     parser : typing.Callable
@@ -68,9 +71,9 @@ def file_parser(parser: typing.Callable) -> typing.Callable:
     """
 
     @functools.wraps(parser)
-    def _wrapper(input_file: str, *args, **kwargs) -> TimeStampedData:
+    def _wrapper(*args, input_file: str, **kwargs) -> TimeStampedData:
         """Full file parser decorator"""
-        _data: TimeStampedData = parser(input_file, *args, **kwargs)
+        _data: TimeStampedData = parser(*args, input_file=input_file, **kwargs)
         _meta_data: typing.Dict[str, str] = {
             "timestamp": datetime.datetime.fromtimestamp(
                 os.path.getmtime(input_file)
@@ -196,9 +199,9 @@ def _full_file_parse(parse_func, in_file, tracked_values, **parser_kwargs) -> Ti
 def record_file(
     input_file: str,
     *,
-    tracked_values: typing.List[re.Pattern[str]] | None = None,
-    parser_func: typing.Callable | None = None,
-    file_type: str | None = None,
+    tracked_values: typing.List[re.Pattern[str]] | None,
+    parser_func: typing.Callable | None,
+    file_type: str | None,
     **parser_kwargs
 ) -> TimeStampedData:
     """Record a recognised file, parsing its contents.
@@ -246,3 +249,15 @@ def record_file(
         f"The file extension '{_extension}' for file '{input_file}' is not supported for 'record_file' without custom parsing"
     )
     raise TypeError(f"File of type '{_extension}' could not be recognised")
+
+
+record_toml.__skip_validation = True
+record_csv.__skip_validation = True
+record_json.__skip_validation = True
+record_yaml.__skip_validation = True
+record_feather.__skip_validation = True
+record_pickle.__skip_validation = True
+record_parquet.__skip_validation = True
+record_fortran_nml.__skip_validation = True
+record_file.__skip_validation = True
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -164,10 +164,10 @@ def fake_log(request) -> (
             target=_write_dummy_data, args=(_file_name,)
         )
         _process.start()
+        time.sleep(0.1)
         yield {
             "path_glob_exprs": _file_name,
             "tracked_values": (_rand_regex_1, _rand_regex_2),
             "labels": ("var_1", "var_2") if _labels else (None, None)
         }
         _process.join()
-        time.sleep(1)

--- a/tests/scenarios/test_class_based_parsing.py
+++ b/tests/scenarios/test_class_based_parsing.py
@@ -1,0 +1,55 @@
+import tempfile
+import os.path
+import logging
+import multiparser.parsing.file as mp_file_parser
+import multiparser.parsing.tail as mp_log_parser
+import multiparser
+import json
+
+
+class ParserClass:
+    
+    @mp_file_parser.file_parser
+    def _custom_file_parser(
+        self,
+        input_file: str,
+        **__):
+        return {}, json.load(open(input_file))
+
+    @mp_log_parser.log_parser
+    def _custom_log_parser(
+        self,
+        file_content: str,
+        **__):
+        return {}, {"input": file_content}
+
+    def _my_callback(
+        self,
+        data,
+        metadata
+    ):
+        print(data)
+
+    def launch(self):
+        # Start an instance of the file monitor, to keep track of log and results files
+        with multiparser.FileMonitor(log_level=logging.DEBUG, terminate_all_on_fail=False, timeout=1
+        ) as self.file_monitor:
+            # Monitor each file created by a Vector PostProcessor, and upload results to Simvue if file matches an expected form.
+            self.file_monitor.track(
+                path_glob_exprs =  "test.json",
+                parser_func = self._custom_file_parser,
+                callback = self._my_callback,
+            )
+            self.file_monitor.tail(
+                path_glob_exprs =  "test.json",
+                parser_func = self._custom_log_parser,
+                callback = self._my_callback,
+            )
+            self.file_monitor.run()
+
+def test_class_based_parsers() -> None:
+    with tempfile.TemporaryDirectory() as temp_d:
+        with open(os.path.join(temp_d, "test.json"), "w") as out_f:
+            json.dump({"x": 2}, out_f)
+        ParserClass().launch()
+

--- a/tests/test_data_parsing.py
+++ b/tests/test_data_parsing.py
@@ -11,6 +11,7 @@ from conftest import fake_csv, fake_feather, fake_nml, fake_toml
 
 import multiparser.parsing as mp_parse
 from multiparser.parsing.file import (
+    file_parser,
     record_csv as file_record_csv,
     record_fortran_nml,
     record_feather,

--- a/tests/test_data_parsing.py
+++ b/tests/test_data_parsing.py
@@ -34,7 +34,7 @@ def test_parse_f90nml() -> None:
     with tempfile.TemporaryDirectory() as temp_d:
         _data_file = fake_nml(temp_d)
         _meta, _data = record_fortran_nml(input_file=_data_file)
-        _, _data2 = mp_parse.record_file(_data_file, None, None, None)
+        _, _data2 = mp_parse.record_file(_data_file, tracked_values=None, parser_func=None, file_type=None)
         assert "timestamp" in _meta
         assert list(sorted(_data.items())) == sorted(_data2.items())
 
@@ -44,7 +44,7 @@ def test_parse_csv() -> None:
     with tempfile.TemporaryDirectory() as temp_d:
         _data_file = fake_csv(temp_d)
         _meta, _data = file_record_csv(input_file=_data_file)
-        _, _data2 = mp_parse.record_file(_data_file, None, None, None)
+        _, _data2 = mp_parse.record_file(_data_file, tracked_values=None, parser_func=None, file_type=None)
         assert "timestamp" in _meta
         assert sorted([i.items() for i in _data]) == sorted([i.items() for i in _data2])
 
@@ -65,7 +65,7 @@ def test_parse_toml() -> None:
     with tempfile.TemporaryDirectory() as temp_d:
         _data_file = fake_toml(temp_d)
         _meta, _data = record_toml(input_file=_data_file)
-        _, _data2 = mp_parse.record_file(_data_file, None, None, None)
+        _, _data2 = mp_parse.record_file(_data_file, tracked_values=None, parser_func=None, file_type=None)
         assert "timestamp" in _meta
         assert list(sorted(_data.items())) == sorted(_data2.items())
 
@@ -76,7 +76,7 @@ def test_unrecognised_file_type() -> None:
         with open(temp_f.name, "w") as out_f:
             out_f.write("...")
         with pytest.raises(TypeError):
-            mp_parse.record_file(temp_f.name, None, None)
+            mp_parse.record_file(temp_f.name, tracked_values=None, parser_func=None, file_type=None)
 
 
 @pytest.mark.parsing

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -21,7 +21,7 @@ import multiparser.exceptions as mp_exc
 import multiparser.thread as mp_thread
 import multiparser.parsing as mp_parse
 from tests.conftest import fake_feather, fake_json, fake_parquet, fake_pickle, fake_yaml
-from multiparser.parsing.tail import record_with_delimiter as tail_record_delimited
+from multiparser.parsing.tail import log_parser, record_with_delimiter as tail_record_delimited
 from multiparser.parsing.file import file_parser
 
 
@@ -494,6 +494,127 @@ def test_timeout_trigger() -> None:
             raise AssertionError("Test failed due to infinite loop")
         assert _test_passed.value == _timeout
 
+
+@pytest.mark.parsing
+@pytest.mark.parametrize(
+    "scenario", ("invalid_argument", "no_arbitrary_keyword_args", "undecorated")
+)
+@pytest.mark.parametrize(
+    "parser_type", ("file", "log")
+)
+def test_check_invalid_parser_functions(scenario: str, parser_type: str) -> None:
+    if scenario == "invalid_argument":
+        parser_func = lambda file_line: ({}, {})
+    elif parser_type == "log":
+        if scenario == "no_arbitrary_keyword_args":
+            parser_func = lambda file_content: ({}, {})
+        else:
+            parser_func = lambda file_content, **_: ({}, {})
+    elif parser_type == "file":
+        if scenario == "no_arbitrary_keyword_args":
+            parser_func = lambda input_file: ({}, {})
+        else:
+            parser_func = lambda input_file, **_: ({}, {})
+
+    if scenario != "undecorated":
+        parser_func = file_parser(parser_func) if parser_type == "file" else log_parser(parser_func)
+
+    with multiparser.FileMonitor(
+        log_level=logging.DEBUG,
+        timeout=2,
+        terminate_all_on_fail=True
+    ) as monitor:
+        with pytest.raises(AssertionError) as exc:
+            if parser_type == "file":
+                monitor.track(
+                    path_glob_exprs="*",
+                    parser_func=parser_func,
+                    static=True
+                )
+            else:
+                monitor.tail(
+                    path_glob_exprs="*",
+                    parser_func=parser_func,
+                )
+            monitor.run()
+
+    if scenario == "invalid_argument":
+        _exception = f"Expected keyword argument '{'input_file' if parser_type == 'file' else 'file_content'}'"
+    elif scenario == "undecorated":
+        _exception = f"must be decorated using the multiparser.{parser_type}_parser decorator"
+    else:
+        _exception = "must allow arbitrary number of keyword arguments"
+
+    assert _exception in str(exc.value)
+
+
+@pytest.mark.parsing
+def test_file_parser_with_args() -> None:
+    @file_parser
+    def parse_file(input_file: str, skip_lines: int, **_) -> tuple[dict, dict]:
+        with open(input_file) as in_file:
+            lines = in_file.readlines()
+        if skip_lines:
+            lines = lines[skip_lines:]
+        return {}, {"lines": lines}
+
+
+    with tempfile.TemporaryDirectory() as temp_d:
+        _data_file = fake_csv(temp_d)
+        _skip_lines = 2
+        with open(_data_file) as in_f:
+            n_lines = len(in_f.readlines())
+
+        def callback_check(data, _, n_lines=n_lines) -> None:
+            assert len(data["lines"]) == n_lines - _skip_lines
+
+        with multiparser.FileMonitor(
+            per_thread_callback=callback_check,
+            log_level=logging.DEBUG,
+            timeout=2,
+            terminate_all_on_fail=True
+        ) as monitor:
+            monitor.track(
+                path_glob_exprs=_data_file,
+                parser_func=parse_file,
+                parser_kwargs={"skip_lines": _skip_lines},
+                static=True
+            )
+            monitor.run()
+
+
+@pytest.mark.parsing
+def test_log_parser_with_args() -> None:
+    @log_parser
+    def parse_line(file_content: str, word_count: int, **_) -> tuple[dict, dict]:
+        _words = file_content.split(" ")
+        if word_count:
+            if len(_words) < word_count:
+                _words = word_count * [_words]
+            _words = _words[:word_count]
+        return {}, {"words": _words}
+
+
+    with tempfile.TemporaryDirectory() as temp_d:
+        _data_file = fake_csv(temp_d)
+        _word_count = 2
+
+        def callback_check(data, _, word_count=_word_count) -> None:
+            assert len(data["words"]) == _word_count
+
+        with multiparser.FileMonitor(
+            per_thread_callback=callback_check,
+            log_level=logging.DEBUG,
+            timeout=2,
+            terminate_all_on_fail=True
+        ) as monitor:
+            monitor.tail(
+                path_glob_exprs=_data_file,
+                parser_func=parse_line,
+                parser_kwargs={"word_count": _word_count},
+            )
+            monitor.run()
+        
 
 @pytest.mark.monitor
 @pytest.mark.parametrize(


### PR DESCRIPTION
## 📝 Summary
* Allows the user to specify kwargs which should be forwarded and used by their custom parser, e.g.:
    ```python
    @log_parser
    def my_parser(file_content: str, skip_first_line: bool):
        ...
    ```
    would be used as:
    ```python
    file_monitor.tail(
        path_glob_exprs="custom_file.log",
        parser_func=my_parser,
        parser_kwargs={"skip_first_line": True}
    )
    ```
* Also allows use of class methods as parsers:
    - This makes use of the keyword arguments `file_content` and `input_file` for log and file parsers respectively mandatory.
    - Any positional or keyword arguments besides these are handed to the parser call. This means `self` is forwarded correctly (see docs).

Closes #102

## ✅ Checks
- [X] Unit tests running locally.
- [ ] Pre-commit hooks run and passing.
- [X] If a feature/bug fix, an issue has been opened and linked to this pull request.
- [X] Documentation has been updated both within the code and in `docs` where appropriate.
